### PR TITLE
Add certificate priority option

### DIFF
--- a/src/main/java/org/cloudburstmc/proxypass/Configuration.java
+++ b/src/main/java/org/cloudburstmc/proxypass/Configuration.java
@@ -27,6 +27,8 @@ public class Configuration {
     private boolean onlineMode = true;
     @JsonProperty("save-auth-details")
     private boolean saveAuthDetails = true;
+    @JsonProperty("force-certificate-chain")
+    private boolean forceCertificateChain = false;
     @JsonProperty("packet-testing")
     private boolean packetTesting = false;
     @JsonProperty("log-packets")

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,6 +11,8 @@ destination:
 online-mode: true
 ## Save credentials when in online mode for future logins.
 save-auth-details: true
+## Forces ProxyPass to use certificate chain auth as opposed to the new token auth
+force-certificate-chain: false
 ## Maximum of clients which can connect to ProxyPass. If this should be disabled, set it to 0.
 max-clients: 0
 ## Encode and decode packets to test protocol library for bugs
@@ -20,6 +22,8 @@ log-packets: true
 ## Where to log packet data
 ## Valid options: console, file or both
 log-to: file
+## Enables the UI
+enable-ui: false
 ## If ProxyPass should follow transfer packets.
 follow-transfers: true
 ## If ProxyPass should download packs from the destination server.


### PR DESCRIPTION
Adds an option which will prioritise the certificate chain when reading the JWT instead of the token.

Also adds the UI as a config option in `config.yml` since that was missing.